### PR TITLE
[FIX] Fields with "old" values

### DIFF
--- a/lib/create-initial-user.js
+++ b/lib/create-initial-user.js
@@ -1,16 +1,19 @@
-var utils = require('./utils/utils');
-var uuid = require('uuid');
-var conf = require('../config');
-var createUser = require('./create-user');
+const utils = require('./utils/utils'),
+  uuid = require('uuid'),
+  log = require('fruster-log'),
+  conf = require('../config'),
+  createUser = require('./create-user');
 
-module.exports = function(db) {
-  
+module.exports = function (db) {
+
   const userCollection = db.collection(conf.userCollection);
   const initialUserCollection = db.collection("initial-user");
 
-  function checkIfInitialUserExists() {    
-    return userCollection.findOne({email: conf.initialUserEmail}).then(user => {
-      if(!user) {
+  function checkIfInitialUserExists()  {
+    return userCollection.findOne({
+      email: conf.initialUserEmail
+    }).then(user => {
+      if (!user) {
         return initialUserCollection.findOne().then(u => !!u);
       }
       return true;
@@ -19,8 +22,8 @@ module.exports = function(db) {
 
   function createInitialUser() {
     createUser.init(userCollection);
-    
-    console.log("Creating initial user", conf.initialUserEmail);
+
+    log.debug("Creating initial user", conf.initialUserEmail);
 
     var user = {
       email: conf.initialUserEmail,
@@ -30,16 +33,15 @@ module.exports = function(db) {
       roles: ["super-admin"]
     };
 
-    return createUser.handle({ data: user })
-      .then(() => initialUserCollection.insert({ _id: uuid.v4(), email: user.email }));
+    return createUser.handle({
+        data: user
+      })
+      .then(() => initialUserCollection.insert({
+        _id: uuid.v4(),
+        email: user.email
+      }));
   }
 
   return checkIfInitialUserExists()
     .then(exists => exists ? Promise.resolve() : createInitialUser());
 };
-
-
-
-
-
-

--- a/lib/update-user.js
+++ b/lib/update-user.js
@@ -10,7 +10,7 @@ updateUser.init = db => {
 };
 
 updateUser.handle = request => {
-	var id = request.data.id;
+	var userId = request.data.id;
 	var updateUserData = request.data;
 
 	if (_.size(updateUserData) === 0) {
@@ -43,40 +43,38 @@ updateUser.handle = request => {
 			return utils.errors.invalidEmail(updateUserData.email);
 		}
 
-		return utils.validateEmailIsUnique(updateUserData.email, database)
+		return utils.validateEmailIsUnique(updateUserData.email, database, userId)
 			.then(emailIsUnique => {
 				if (!emailIsUnique) {
 					return utils.errors.emailNotUnique(updateUserData.email);
 				} else {
-					return updateInDatabase(updateUserData, id);
+					return updateInDatabase(updateUserData, userId);
 				}
 			});
 	}
 
-	return updateInDatabase(updateUserData, id);
+	return updateInDatabase(updateUserData, userId);
 };
 
-function updateInDatabase(updateUserData, id) {
+function updateInDatabase(updateUserData, userId) {
 	return database
 		.update({
-			id: id
+			id: userId
 		}, {
 			$set: updateUserData
 		})
 		.then(response => {
 			if (response.result.nModified === 1) {
 				return database.findOne({
-					id: id
-				});
+						id: userId
+					})
+					.then(updatedUserFromDatabase => utils.ok(utils.cleanUserModelOutput(updatedUserFromDatabase)));
 			} else {
 				if (response.result.n === 0) {
-					return utils.errors.userNotFound(id);
+					return utils.errors.userNotFound(userId);
 				} else {
-					return utils.errors.userNotUpdated($set);
+					return utils.ok();
 				}
 			}
-		})
-		.then(updatedUserFromDatabase => {
-			return utils.ok(utils.cleanUserModelOutput(updatedUserFromDatabase));
 		});
 }

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -1,10 +1,8 @@
-"use strict";
+const conf = require('../../config'),
+	_ = require('lodash'),
+	errors = require('./errors'),
 
-var conf = require('../../config');
-var _ = require('lodash');
-var errors = require('./errors');
-
-var utils = module.exports = {};
+	utils = module.exports = {};
 
 utils.errors = errors;
 
@@ -77,7 +75,6 @@ utils.cleanUserModelOutput = user => {
 
 	var rolesWithPermissions = utils.getRoles();
 
-
 	user.roles.forEach(role => {
 		if (rolesWithPermissions[role]) {
 			rolesWithPermissions[role].forEach(permission => {
@@ -92,7 +89,6 @@ utils.cleanUserModelOutput = user => {
 };
 
 utils.getScopesForRoles = roles => {
-
 	let scopes = [];
 	var rolesWithPermissions = utils.getRoles();
 
@@ -107,21 +103,23 @@ utils.getScopesForRoles = roles => {
 	});
 
 	return scopes;
-
 };
 
 utils.validateEmail = email => {
 	return new RegExp(conf.emailValidationRegex).test(email);
 };
 
-utils.validateEmailIsUnique = (email, database) => {
+utils.validateEmailIsUnique = (email, database, userId) => {
 	return database
 		.findOne({
 			'email': email
 		})
 		.then(result => {
 			if (!!result) {
-				return false;
+				if (userId)
+					return result.id === userId;
+				else
+					return false;
 			} else {
 				return true;
 			}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "crypto-js": "^3.1.8",
     "csprng": "^0.1.1",
     "fruster-bus": "0.1.5",
+    "fruster-log": "0.0.9",
     "fruster-health": "0.0.6",
     "lodash": "^4.17.2",
     "mongodb-bluebird": "^0.1.1",

--- a/spec/fruster-user-service-spec.js
+++ b/spec/fruster-user-service-spec.js
@@ -542,6 +542,57 @@ describe("Fruster - User service", () => {
 			});
 	});
 
+	it("Should be possible to send old email with update request", done => {
+		let user = getUserObject(),
+			id,
+			email = user.email;
+
+		createUser(user)
+			.then((createdUserResponse) => {
+				id = createdUserResponse.data.id;
+				user.email = email;
+			})
+			.then(createdUserResponse => {
+				return bus.request("user-service.update-user", {
+						data: {
+							id: id,
+							email: email,
+							firstName: "greg"
+						}
+					}, 1000)
+					.then(updateResponse => {
+						expect(updateResponse.status).toBe(200);
+						done();
+					});
+			});
+	});
+
+	it("Should not return error if no fields are updated", done => {
+		let user = getUserObject(),
+			id,
+			email = user.email;
+
+		createUser(user)
+			.then((createdUserResponse) => {
+				id = createdUserResponse.data.id;
+				user.email = email;
+			})
+			.then(createdUserResponse => {
+				return bus.request("user-service.update-user", {
+						data: {
+							id: id,
+							email: email,
+							firstName: user.firstName,
+							lastName: user.lastName
+						}
+					}, 1000)
+					.then(updateResponse => {
+						expect(updateResponse.status).toBe(200);
+						done();
+					});
+			});
+	});
+
 	it("Should return 200 when user is successfully removed", done => {
 		var user = getUserObject();
 


### PR DESCRIPTION
Fixes https://github.com/FrostDigital/fruster-user-service/issues/18 and https://github.com/FrostDigital/fruster-user-service/issues/17

Makes it possible to send fields with "old" (Same value as in database) values when updating a user. 

* It no longer complains about non-unique email if the email already belongs to the user trying to update its account.
* It no longer complains about all fields having the same value as in the one in database. 