### PR TITLE
[FIX] Makes it possible to login as an old user created before requireEmailVerification was set to true

### DIFF
--- a/lib/validate-password.js
+++ b/lib/validate-password.js
@@ -22,7 +22,7 @@ validatePassword.handle = async (request, replyTo) => {
 
 	const user = await database.findOne({ 'email': username.toLowerCase() });
 
-	if (conf.requireEmailVerification && !user.emailVerified)
+	if (conf.requireEmailVerification && user.hasOwnProperty("emailVerified") && !user.emailVerified)
 		throw errors.throw("EMAIL_NOT_VERIFIED");
 	else if (user) {
 		if (passwordUtils.validatePassword(user.password, user.salt, user.id, password, user.hashDate))

--- a/spec/validate-password.spec.js
+++ b/spec/validate-password.spec.js
@@ -143,7 +143,6 @@ describe("fruster user service validate password", () => {
             conf.requireEmailVerification = true;
 
             const user = mocks.getUserObject();
-            user.emailVerified = false;
 
             await bus.request(constants.endpoints.service.CREATE_USER, { data: user });
             const response = await bus.request(constants.endpoints.service.VALIDATE_PASSWORD,
@@ -157,6 +156,30 @@ describe("fruster user service validate password", () => {
             done();
             conf.requireEmailVerification = false;
         }
+    });
+
+    it("should be possible for old accounts to login even if the email has not been verified", async done => {
+        try {
+            mocks.mockMailService();
+
+            const user = mocks.getUserObject();
+
+            await bus.request(constants.endpoints.service.CREATE_USER, { data: user });
+
+            conf.requireEmailVerification = true;
+
+            const response = await bus.request(constants.endpoints.service.VALIDATE_PASSWORD,
+                { data: { username: user.email, password: user.password } });
+
+            expect(response.status).toBe(200);
+            expect(_.size(response.error)).toBe(0);
+
+            done();
+        } catch (err) {
+            testUtils.fail(done, err);
+        }
+
+        conf.requireEmailVerification = false;
     });
 
 });


### PR DESCRIPTION
If users registered before the `requireEmailVerification` flag was set to true they won't have a `emailVerified` flag in their object. Previously this would result in the code interpreting this as false, email is not verified. Now we instead check if this field exists and if it doesn't we grant them access (This is the only case it will happen since any new user will get this field set to false).