### PR TITLE
adds default false to verify email

### DIFF
--- a/config.js
+++ b/config.js
@@ -29,7 +29,7 @@ module.exports = {
 	requirePassword: parseBool(process.env.REQUIRE_PASSWORD || "true"),
 
 	// Wether or not to require the users to verify their email address before being able to signin. If this is set to true a web server will run providing a simple request new token / verify frontend @ /resend-verification & /verify-email:tokenId
-	requireEmailVerification: process.env.REQUIRE_EMAIL_VERIFICATION === "true",
+	requireEmailVerification: parseBool(process.env.REQUIRE_EMAIL_VERIFICATION) ||  false,
 
 	// HTTP port where email verification web will run
 	port: process.env.PORT || 3120,


### PR DESCRIPTION
adds the default value false to require email, because not setting it at all leads to unpredictable behaviour (currently in paceup) both when creating and updating a profile. _sometimes_ it goes into this if-statement https://github.com/FrostDigital/fruster-user-service/blob/develop/lib/create-user.js#L22
sometimes not.

_sometimes_ it goes into this if-statement: https://github.com/FrostDigital/fruster-user-service/blob/develop/lib/update-user.js#L46 sometimes not. 

Not sure if this solves it, but at least it is more readable (to me)

@Florry or @joelso please review and let me know what you think and if you have any other ideas on how to solve my problem