### PR TITLE
[FIX] skipOptionsRequest for send mail

### DIFF
--- a/lib/clients/mail-service-client.js
+++ b/lib/clients/mail-service-client.js
@@ -15,7 +15,6 @@ class MailServiceClient {
     async send(reqId, to, subject, body) {
         const req = {
             reqId: reqId,
-            skipOptionsRequest: true,
             data: {
                 to: [to],
                 from: this.from,
@@ -24,7 +23,11 @@ class MailServiceClient {
             }
         };
 
-        return await bus.request(this.endpoints.SEND, req);
+        return await bus.request({
+            subject: this.endpoints.SEND,
+            skipOptionsRequest: true,
+            message: req
+        });
     }
 
     /**


### PR DESCRIPTION
Corrects placement of `skipOptionsRequest` in the mail service client's send function.