### PR TITLE
Adds logs for slow queries

### DIFF
--- a/config.js
+++ b/config.js
@@ -87,7 +87,10 @@ module.exports = {
 	requirePasswordOnEmailUpdate: process.env.REQUIRE_PASSWORD_ON_EMAIL_UPDATE === "true",
 
 	/** Whether or not to require a new user to have firstName and lastName */
-	requireNames: parseBool(process.env.REQUIRE_NAMES || "true")
+	requireNames: parseBool(process.env.REQUIRE_NAMES || "true"),
+
+	/** Treshold for what is considered to be a slow query. If slow, this will be logged */
+	slowQueryTresholdMs: parseInt(process.env.SLOW_QUERY_TRESHOLD_MS || "250")
 
 };
 

--- a/lib/repos/UserRepo.js
+++ b/lib/repos/UserRepo.js
@@ -28,6 +28,7 @@ class UserRepo {
 	 * @return {Promise<Array<>>}
 	 */
 	async getUsersByQuery(query = {}, start = 0, limit = 0, filter = {}, sort = {}) {
+		const startTime = Date.now();
 		const dbFilter = Object.assign(filter, { _id: 0 });
 
 		try {
@@ -38,12 +39,19 @@ class UserRepo {
 				.limit(limit);
 
 			const usersFromDatabase = await mongoQueryOperation.toArray();
+
 			let totalCount;
 
 			if (limit)
 				totalCount = await mongoQueryOperation.count();
 			else
 				totalCount = usersFromDatabase.length;
+
+			const queryDuration = Date.now() - startTime;
+
+			if (queryDuration >= config.slowQueryTresholdMs) {
+				log.warn(`SLOW QUERY DETECTED: Duration ${queryDuration}ms, query ${JSON.stringify(query)}, filter ${JSON.stringify(dbFilter)}`)
+			}
 
 			return [usersFromDatabase.map(u => new UserModel(u, Object.keys(filter).length > 0)), totalCount];
 		} catch (err) {

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
         "jasmine": "2.8.0",
         "jasmine-spec-reporter": "^4.2.1",
         "nats-server-control": "0.0.1",
-        "nyc": "^11.4.1",
-        "request": "^2.79.0"
+        "nyc": "^11.4.1"
     },
     "engines": {
         "node": "7.10.0"


### PR DESCRIPTION
Add log for slow db queries. This can be used to debug get-user-by-query.

What is considered to be a slow query is configurable with `SLOW_QUERY_TRESHOLD_MS` and defaults to 250 ms.