### PR TITLE
[FIX] Expand if it has profile separation

### DIFF
--- a/lib/repos/UserRepo.js
+++ b/lib/repos/UserRepo.js
@@ -73,7 +73,10 @@ class UserRepo {
 	 */
 	async _aggregateResult(query, start = 0, limit = 0, filter, sort, doExpand, caseInsensitiveSort) {
 		/** @type {Array} */
-		const aggregation = doExpand ? this._getExpandAggregation(query) : [{ $match: query }];
+		const aggregation = doExpand &&
+			!(config.userFields.includes(constants.dataset.ALL_FIELDS)
+				&& config.profileFields.includes(constants.dataset.ALL_FIELDS)
+			) ? this._getExpandAggregation(query) : [{ $match: query }];
 
 		const hasSort = Object.keys(sort).length > 0;
 		const hasFilter = Object.keys(filter).length > 0;
@@ -309,9 +312,9 @@ class UserRepo {
 				{
 					id
 				}, {
-					$set: { "metadata.updated": new Date() },
-					$push: { roles: { $each: rolesToAdd } }
-				});
+				$set: { "metadata.updated": new Date() },
+				$push: { roles: { $each: rolesToAdd } }
+			});
 		} catch (err) {
 			throw errors.get("fruster-user-service.INTERNAL_SERVER_ERROR", err);
 		}
@@ -336,9 +339,9 @@ class UserRepo {
 				{
 					id
 				}, {
-					$set: { "metadata.updated": new Date() },
-					$pull: { roles: { $in: rolesToRemove } }
-				});
+				$set: { "metadata.updated": new Date() },
+				$pull: { roles: { $in: rolesToRemove } }
+			});
 		} catch (err) {
 			throw errors.get("fruster-user-service.INTERNAL_SERVER_ERROR", err);
 		}


### PR DESCRIPTION
The auth service sends service call to get auth user for `user-service.get-users-by-query` with `expand: 'true"`. So it is not send `profile` attributes if user service not such separation for profile and user. 
https://github.com/FrostDigital/fruster-auth-service/blob/develop/lib/managers/UserManager.js#L28