### PR TITLE
[FIX] find email template by exact match user role

### DIFF
--- a/lib/utils/EmailUtils.js
+++ b/lib/utils/EmailUtils.js
@@ -52,7 +52,7 @@ class EmailUtils {
 			const [rolesCSV, templateId] = row.split(":");
 
 			for (const role of roles)
-				if (rolesCSV.includes(role))
+				if (rolesCSV.split(",").includes(role))
 					return templateId;
 		}
 


### PR DESCRIPTION
Because `consultant` is getting `organisation_consultant_manager`'s email template. (I was searching "consultant" word in the roleCSV.)