### PR TITLE
[FIX] Unset fields in user-service.update-profile call

### DIFF
--- a/lib/handlers/UpdateProfileHandler.js
+++ b/lib/handlers/UpdateProfileHandler.js
@@ -30,7 +30,10 @@ class UpdateProfileHandler {
 
 		profile = this._userManager.validateUpdateData(profile);
 
-		const updatedProfile = await this._profileManager.updateProfile(id, profile);
+		const unset = profile.$unset;
+		delete profile.$unset;
+
+		const updatedProfile = await this._profileManager.updateProfile(id, profile, unset);
 
 		return {
 			status: 200,

--- a/lib/managers/ProfileManager.js
+++ b/lib/managers/ProfileManager.js
@@ -34,8 +34,8 @@ class ProfileManager {
 	 *
 	 * @return {Promise<ProfileModel>}
 	 */
-	updateProfile(id, updateData) {
-		return this._profileRepo.updateProfile(id, updateData);
+	updateProfile(id, updateData, unsetData) {
+		return this._profileRepo.updateProfile(id, updateData, unsetData);
 	}
 
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 				"uuid": "^10.0.0"
 			},
 			"devDependencies": {
-				"fruster-test-utils": "^0.7.0",
+				"fruster-test-utils": "^0.7.1",
 				"jasmine": "5.4.0",
 				"jasmine-spec-reporter": "^7.0.0",
 				"nyc": "^17.1.0"
@@ -2936,9 +2936,9 @@
 			}
 		},
 		"node_modules/fruster-test-utils": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/fruster-test-utils/-/fruster-test-utils-0.7.0.tgz",
-			"integrity": "sha512-7I7RWRzUuGogdWGXuwH3dXo2ozTsn+Ucd+ZO8WOQvjoXhmj0/+gT7PuHJjwVieCX1u/e4DpUn4TJrTlPAvzbPA==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/fruster-test-utils/-/fruster-test-utils-0.7.2.tgz",
+			"integrity": "sha512-AcPTBkDYgl6smenL/oVmdqiPIe02ToZP2R6oUFs31rSkskm2iXEtkA9SJn9PxCax0nLQ6+i10NwLQmMydu0dlg==",
 			"dev": true,
 			"dependencies": {
 				"fruster-bus": "0.7.12",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"uuid": "^10.0.0"
 	},
 	"devDependencies": {
-		"fruster-test-utils": "^0.7.1",
+		"fruster-test-utils": "^0.7.2",
 		"jasmine": "5.4.0",
 		"jasmine-spec-reporter": "^7.0.0",
 		"nyc": "^17.1.0"

--- a/schemas/UpdateProfileRequest.json
+++ b/schemas/UpdateProfileRequest.json
@@ -17,7 +17,14 @@
         },
         "email": {
             "$ref": "User#/properties/email"
-        }
+        },
+		"$unset": {
+			"type": "object",
+			"description": "List of fields to unset (remove)",
+			"items": {
+				"type": "string"
+			}
+		}
     },
     "required": [
         "id"

--- a/spec/support/spec-constants.js
+++ b/spec/support/spec-constants.js
@@ -14,6 +14,7 @@ module.exports = {
 			service,
 			afterStart,
 			mongoUrl: `mongodb://localhost:27017/${constants.SERVICE_NAME}-test`,
+			dropDatabase: true
 		};
 	}
 


### PR DESCRIPTION
Makes it possible to remove fields from `profile`, using `data.$unset` field on service endpoint `user-service.update-profile`
This was already partially implemented in the repo. 

I don't _think_ this will have any implication for other applications, since  $unset field is optional, but i might miss something!